### PR TITLE
Use npx to run http-server command

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start-server": "http-server --cors -c-1",
+    "start-server": "npx http-server --cors -c-1",
     "start-webpack": "export NODE_OPTIONS=--openssl-legacy-provider && webpack ./src/index.js --output-filename puter.js && webpack ./src/index.js --output-filename puter.dev.js --watch --devtool source-map",
     "start": "concurrently \"npm run start-server\" \"npm run start-webpack\"",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider && webpack ./src/index.js --output-filename puter.js && { echo \"// Copyright 2024 Puter Technologies Inc. All rights reserved.\"; echo \"// Generated on $(date '+%Y-%m-%d %H:%M')\n\"; cat ./dist/puter.js; } > temp && mv temp ./dist/puter.js"


### PR DESCRIPTION
This otherwise fails for me, complaining that http-server is not found. `npx http-server ...` is how we invoke this in the other repos so I think it's more correct.