### PR TITLE
Set uuid on launchApp messages

### DIFF
--- a/src/modules/UI.js
+++ b/src/modules/UI.js
@@ -726,6 +726,7 @@ class UI{
                 app_name: appName,
                 args: args,
                 appInstanceID: this.appInstanceID,
+                uuid: msg_id,
             }, '*');
 
             //register callback


### PR DESCRIPTION
Otherwise, the promise from puter.ui.launchApp() never resolves.