### PR TITLE
Implement AppConnection 'close' event and `close()` method

### DIFF
--- a/src/modules/UI.js
+++ b/src/modules/UI.js
@@ -8,6 +8,9 @@ import EventListener  from '../lib/EventListener.js';
 // - postMessage(message)        Send a message to the target app
 // - on('message', callback)     Listen to messages from the target app
 class AppConnection extends EventListener {
+    // targetOrigin for postMessage() calls to Puter
+    #puterOrigin = '*';
+
     // Whether the target app is open
     #isOpen;
 
@@ -20,6 +23,8 @@ class AppConnection extends EventListener {
         this.appInstanceID = appInstanceID;
         this.targetAppInstanceID = targetAppInstanceID;
         this.#isOpen = true;
+
+        // TODO: Set this.#puterOrigin to the puter origin
 
         window.addEventListener('message', event => {
             if (event.data.msg === 'messageToApp') {
@@ -63,10 +68,22 @@ class AppConnection extends EventListener {
             targetAppInstanceID: this.targetAppInstanceID,
             targetAppOrigin: '*', // TODO: Specify this somehow
             contents: message,
-        }, '*'); // TODO: Ensure targetOrigin is Puter GUI specifically?
+        }, this.#puterOrigin);
     }
 
-    // TODO: Implement close()
+    // Attempt to close the target application
+    close() {
+        if (!this.#isOpen) {
+            console.warn('Trying to close an app on a closed AppConnection');
+            return;
+        }
+
+        this.messageTarget.postMessage({
+            msg: 'closeApp',
+            appInstanceID: this.appInstanceID,
+            targetAppInstanceID: this.targetAppInstanceID,
+        }, this.#puterOrigin);
+    }
 }
 
 class UI extends EventListener {

--- a/src/modules/UI.js
+++ b/src/modules/UI.js
@@ -8,24 +8,43 @@ import EventListener  from '../lib/EventListener.js';
 // - postMessage(message)        Send a message to the target app
 // - on('message', callback)     Listen to messages from the target app
 class AppConnection extends EventListener {
+    // Whether the target app is open
+    #isOpen;
+
     constructor(messageTarget, appInstanceID, targetAppInstanceID) {
         super([
             'message', // The target sent us something with postMessage()
-            // TODO: 'close' event when the target is closed
+            'close',   // The target app was closed
         ]);
         this.messageTarget = messageTarget;
         this.appInstanceID = appInstanceID;
         this.targetAppInstanceID = targetAppInstanceID;
+        this.#isOpen = true;
 
         window.addEventListener('message', event => {
-            if (event.data.msg !== 'messageToApp') return;
-            if (event.data.appInstanceID !== this.targetAppInstanceID) {
-                // Message is from a different AppConnection; ignore it.
+            if (event.data.msg === 'messageToApp') {
+                if (event.data.appInstanceID !== this.targetAppInstanceID) {
+                    // Message is from a different AppConnection; ignore it.
+                    return;
+                }
+                if (event.data.targetAppInstanceID !== this.appInstanceID) {
+                    console.error(`AppConnection received message intended for wrong app! appInstanceID=${this.appInstanceID}, target=${event.data.targetAppInstanceID}`);
+                    return;
+                }
+                this.emit('message', event.data.contents);
                 return;
             }
-            if (event.data.targetAppInstanceID !== this.appInstanceID) {
-                console.error(`AppConnection received message intended for wrong app! appInstanceID=${this.appInstanceID}, target=${event.data.targetAppInstanceID}`);
-                return;
+
+            if (event.data.msg === 'appClosed') {
+                if (event.data.appInstanceID !== this.targetAppInstanceID) {
+                    // Message is from a different AppConnection; ignore it.
+                    return;
+                }
+
+                this.#isOpen = false;
+                this.emit('close', {
+                    appInstanceID: this.targetAppInstanceID,
+                });
             }
             console.log(`AppConnection in ${this.appInstanceID} received message from ${event.data.appInstanceID}!`);
             this.emit('message', event.data.contents);
@@ -33,7 +52,11 @@ class AppConnection extends EventListener {
     }
 
     postMessage(message) {
-        console.log(`AppConnection in ${this.appInstanceID} sending message to ${this.targetAppInstanceID}!`);
+        if (!this.#isOpen) {
+            console.warn('Trying to post message on a closed AppConnection');
+            return;
+        }
+
         this.messageTarget.postMessage({
             msg: 'messageToApp',
             appInstanceID: this.appInstanceID,


### PR DESCRIPTION
Two parts to this, both related to closing.

- Add a `close` event to `AppConnection`, which is fired when their target app closes.
- Add a `close()` method to `AppConnection`, to request that the app is closed.

See also https://github.com/HeyPuter/puter/pull/255 which implements the Puter side.